### PR TITLE
Add safe accessor on `name`

### DIFF
--- a/lib/notion_to_md/page.rb
+++ b/lib/notion_to_md/page.rb
@@ -92,7 +92,7 @@ module NotionToMd
         end
 
         def select(prop)
-          prop['select'].name
+          prop['select']&.name
         end
 
         def people(prop)

--- a/spec/notion_to_md/page_spec.rb
+++ b/spec/notion_to_md/page_spec.rb
@@ -8,6 +8,22 @@ describe(NotionToMd::Page) do
 
   subject { described_class.new(page: notion_page, blocks: notion_blocks) }
 
+  describe('#custom_props') do
+    context 'with a null select prop' do
+      let(:notion_page) do
+        Notion::Messages::Message.new(
+          properties: {
+            nil_select: { id: 'xxxx', type: 'select', select: nil }
+          }
+        )
+      end
+
+      it 'excludes the prop from the return' do
+        expect(subject.custom_props).not_to include('nil_select')
+      end
+    end
+  end
+
   describe('icon') do
     context('when is an emoji') do
       let(:emoji) { '\U0001F4A5' }


### PR DESCRIPTION
In the case where the select has no value, notion will return a nil
value on the select property. This was assumed to be present, so calling
`.name` on nil returned an exception.

This adds the safe accessor in the event it's not set, the returned
property value from `NotionToMd::Page::CustomProperty` will also be nil.
