### PR TITLE
Be able to overwrite created_time/last_edit_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ multiple_options: option1, option2
 ---
 ```
 
+If custom property name intersects with default properties, then default value will be used. Two exceptions are `created_time` and `last_edited_time`, you can overwrite them by creating corresponding custom properties.
+
 The supported property types are:
 
 * `number`

--- a/lib/notion_to_md/page.rb
+++ b/lib/notion_to_md/page.rb
@@ -13,7 +13,7 @@ module NotionToMd
       title_list = page.dig(:properties, :Name, :title) || page.dig(:properties, :title, :title)
       title_list.inject('') do |acc, slug|
         acc + slug[:plain_text]
-      end
+      end if title_list
     end
 
     def cover
@@ -29,11 +29,19 @@ module NotionToMd
     end
 
     def created_time
-      DateTime.parse(page['created_time'])
+      if custom_props['created_time']
+        DateTime.parse(custom_props['created_time'])
+      else
+        DateTime.parse(page['created_time'])
+      end
     end
 
     def last_edited_time
-      DateTime.parse(page['last_edited_time'])
+      if custom_props['last_edited_time']
+        DateTime.parse(custom_props['last_edited_time'])
+      else
+        DateTime.parse(page['last_edited_time'])
+      end
     end
 
     def url

--- a/spec/notion_to_md/page_spec.rb
+++ b/spec/notion_to_md/page_spec.rb
@@ -22,6 +22,40 @@ describe(NotionToMd::Page) do
         expect(page.custom_props).not_to include('nil_select')
       end
     end
+
+    context 'when "created_time" is a default property' do
+      let(:default_date) { '2023-08-24' }
+      let(:notion_page) do
+        Notion::Messages::Message.new({
+          created_time: default_date,
+          last_edited_time: default_date,
+          properties: {}
+        })
+      end
+
+      it { expect(page.created_time).to eq(DateTime.parse(default_date)) }
+    end
+
+    context 'when "created_time" is overwritten by properties' do
+      let(:default_date) { '2023-08-24' }
+      let(:overwritten_date) { '2020-12-08' }
+      let(:notion_page) do
+        Notion::Messages::Message.new({
+          created_time: default_date,
+          last_edited_time: default_date,
+          properties: {
+            "Created time": {
+              type: 'date',
+              date: {
+                start: overwritten_date
+              }
+            }
+          }
+        })
+      end
+
+      it { expect(page.created_time).to eq(DateTime.parse(overwritten_date)) }
+    end
   end
 
   describe('#icon') do


### PR DESCRIPTION
Usually the day when I publish the post is not the day when I created it. It is a little bit strange when I'm changing post's visibility after few days of writing and it appears on the site for the first time, but the date is "few days ago". I want to control this parameter but right now I can't.

Property overwriting adds more flexibility, so I think it is good thing to have. It could be even better to allow other properties overwritten too, but I don't see any usecases there. 