### PR TITLE
refactor: normalize blocks

### DIFF
--- a/lib/notion_to_md/blocks.rb
+++ b/lib/notion_to_md/blocks.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative './blocks/builder'
 require_relative './blocks/block'
 require_relative './blocks/factory'
 require_relative './blocks/table_block'
@@ -7,45 +8,17 @@ require_relative './blocks/types'
 
 module NotionToMd
   module Blocks
-    ##
-    # Array containing the block types allowed to have nested blocks (children).
-    PERMITTED_CHILDREN = [
-      Types.method(:bulleted_list_item).name,
-      Types.method(:numbered_list_item).name,
-      Types.method(:paragraph).name,
-      Types.method(:to_do).name,
-      :table
-    ].freeze
-
-    # === Parameters
-    # block::
-    #   A {Notion::Messages::Message}[https://github.com/orbit-love/notion-ruby-client/blob/main/lib/notion/messages/message.rb] object.
-    #
-    # === Returns
-    # A boolean indicating if the blocked passed in
-    # is permitted to have children based on its type.
-    #
-    def self.permitted_children?(block:)
-      PERMITTED_CHILDREN.include?(block.type.to_sym) && block.has_children
-    end
-
     # === Parameters
     # block_id::
     #   A string representing a notion block id .
+    # fetch_blocks::
+    #   A block that fetches the blocks from the Notion API.
     #
     # === Returns
     # An array of NotionToMd::Blocks::Block.
     #
     def self.build(block_id:, &fetch_blocks)
-      blocks = fetch_blocks.call(block_id)
-      blocks.results.map do |block|
-        children = if permitted_children?(block: block)
-                     build(block_id: block.id, &fetch_blocks)
-                   else
-                     []
-                   end
-        Factory.build(block: block, children: children)
-      end
+      Builder.new(block_id: block_id, &fetch_blocks).build
     end
   end
 end

--- a/lib/notion_to_md/blocks.rb
+++ b/lib/notion_to_md/blocks.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require_relative './blocks/builder'
-require_relative './blocks/block'
+require_relative './blocks/normalizer'
 require_relative './blocks/factory'
-require_relative './blocks/table_block'
 require_relative './blocks/types'
+require_relative './blocks/block'
+require_relative './blocks/table_block'
+require_relative './blocks/bulleted_list_block'
+require_relative './blocks/numbered_list_block'
+require_relative './blocks/to_do_list_block'
 
 module NotionToMd
   module Blocks

--- a/lib/notion_to_md/blocks/block.rb
+++ b/lib/notion_to_md/blocks/block.rb
@@ -9,6 +9,8 @@ module NotionToMd
 
       attr_reader :block, :children
 
+      def_delegators :block, :type
+
       # === Parameters:
       # block::
       #   A {Notion::Messages::Message}[https://github.com/orbit-love/notion-ruby-client/blob/main/lib/notion/messages/message.rb] object.

--- a/lib/notion_to_md/blocks/builder.rb
+++ b/lib/notion_to_md/blocks/builder.rb
@@ -47,8 +47,8 @@ module NotionToMd
       # An array of NotionToMd::Blocks::Block.
       #
       def build
-        blocks = fetch_blocks.call(block_id)
-        blocks.results.map do |block|
+        notion_messages = fetch_blocks.call(block_id)
+        blocks = notion_messages.results.map do |block|
           children = if Builder.permitted_children_for?(block: block)
                        Builder.new(block_id: block.id, &fetch_blocks).build
                      else
@@ -56,6 +56,8 @@ module NotionToMd
                      end
           Factory.build(block: block, children: children)
         end
+
+        Normalizer.normalize(blocks: blocks)
       end
     end
   end

--- a/lib/notion_to_md/blocks/builder.rb
+++ b/lib/notion_to_md/blocks/builder.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module NotionToMd
+  module Blocks
+    class Builder
+      ##
+      # Array containing the block types allowed to have nested blocks (children).
+      BLOCKS_WITH_PERMITTED_CHILDREN = [
+        :bulleted_list_item,
+        :numbered_list_item,
+        :paragraph,
+        :to_do,
+        :table
+      ].freeze
+
+      # === Parameters
+      # block::
+      #   A {Notion::Messages::Message}[https://github.com/orbit-love/notion-ruby-client/blob/main/lib/notion/messages/message.rb] object.
+      #
+      # === Returns
+      # A boolean indicating if the blocked passed in
+      # is permitted to have children based on its type.
+      #
+      def self.permitted_children_for?(block:)
+        BLOCKS_WITH_PERMITTED_CHILDREN.include?(block.type.to_sym) && block.has_children
+      end
+
+      attr_reader :block_id, :fetch_blocks
+
+      # === Parameters
+      # block_id::
+      #   A string representing a notion block id .
+      # fetch_blocks::
+      #   A block that fetches the blocks from the Notion API.
+      #
+      # === Returns
+      # An array of NotionToMd::Blocks::Block.
+      #
+      def initialize(block_id:, &fetch_blocks)
+        @block_id = block_id
+        @fetch_blocks = fetch_blocks
+      end
+
+      # === Parameters
+      #
+      # === Returns
+      # An array of NotionToMd::Blocks::Block.
+      #
+      def build
+        blocks = fetch_blocks.call(block_id)
+        blocks.results.map do |block|
+          children = if Builder.permitted_children_for?(block: block)
+                       Builder.new(block_id: block.id, &fetch_blocks).build
+                     else
+                       []
+                     end
+          Factory.build(block: block, children: children)
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_to_md/blocks/bulleted_list_block.rb
+++ b/lib/notion_to_md/blocks/bulleted_list_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module NotionToMd
+  module Blocks
+    class BulletedListBlock < Block
+      def initialize(children: [])
+        @children = children
+      end
+
+      # === Parameters:
+      # tab_width::
+      #  The number of tabs used to indent the block.
+      #
+      # === Returns
+      # The current block (and its children) converted to a markdown string.
+      #
+      def to_md(tab_width: 0)
+        build_nested_blocks(tab_width)
+      end
+    end
+  end
+end

--- a/lib/notion_to_md/blocks/bulleted_list_block.rb
+++ b/lib/notion_to_md/blocks/bulleted_list_block.rb
@@ -17,6 +17,10 @@ module NotionToMd
       def to_md(tab_width: 0)
         build_nested_blocks(tab_width)
       end
+
+      def type
+        "bulleted_list"
+      end
     end
   end
 end

--- a/lib/notion_to_md/blocks/normalizer.rb
+++ b/lib/notion_to_md/blocks/normalizer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module NotionToMd
+  module Blocks
+    class Normalizer
+      # === Parameters
+      # blocks::
+      #  An array of NotionToMd::Blocks::Block.
+      #
+      def self.normalize(blocks:)
+        new(blocks: blocks).normalize
+      end
+
+      attr_reader :blocks
+
+      def initialize(blocks:)
+        @blocks = blocks
+      end
+
+      def normalize
+        normalize_for :bulleted_list_item
+        normalize_for :numbered_list_item
+        normalize_for :to_do
+      end
+
+      private
+
+      def normalized_blocks
+        @normalized_blocks ||= blocks.clone
+      end
+
+      def normalize_for(type)
+        new_blocks = []
+
+        normalized_blocks.each do |block|
+          if block.type.to_sym == type
+            blocks_to_normalize << block
+          else
+            if blocks_to_normalize.any?
+              new_blocks << new_block_for(type, children: blocks_to_normalize)
+              reset_blocks_to_normalize
+            end
+            new_blocks << block
+          end
+        end
+
+        normalized_blocks = new_blocks
+      end
+
+      def blocks_to_normalize
+        @blocks_to_normalize ||= []
+      end
+
+      def reset_blocks_to_normalize
+        @blocks_to_normalize = []
+      end
+
+      def new_block_for(type, children:)
+        case type
+        when :bulleted_list_item
+          BulletedListBlock.new(children: children)
+        when :numbered_list_item
+          NumberedListBlock.new(children: children)
+        when :to_do
+          ToDoListBlock.new(children: children)
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_to_md/blocks/numbered_list_block.rb
+++ b/lib/notion_to_md/blocks/numbered_list_block.rb
@@ -3,6 +3,9 @@
 module NotionToMd
   module Blocks
     class NumberedListBlock < BulletedListBlock
+      def type
+        "numbered_list"
+      end
     end
   end
 end

--- a/lib/notion_to_md/blocks/numbered_list_block.rb
+++ b/lib/notion_to_md/blocks/numbered_list_block.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module NotionToMd
+  module Blocks
+    class NumberedListBlock < BulletedListBlock
+    end
+  end
+end

--- a/lib/notion_to_md/blocks/to_do_list_block.rb
+++ b/lib/notion_to_md/blocks/to_do_list_block.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module NotionToMd
+  module Blocks
+    class ToDoListBlock < BulletedListBlock
+    end
+  end
+end

--- a/lib/notion_to_md/blocks/to_do_list_block.rb
+++ b/lib/notion_to_md/blocks/to_do_list_block.rb
@@ -3,6 +3,9 @@
 module NotionToMd
   module Blocks
     class ToDoListBlock < BulletedListBlock
+      def type
+        "to_do_list"
+      end
     end
   end
 end

--- a/spec/notion_to_md/blocks/builder_spec.rb
+++ b/spec/notion_to_md/blocks/builder_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe(NotionToMd::Blocks::Builder) do
+  describe('.permitted_children_for?') do
+    context('when has children and is permitted') do
+      let(:block_notion) { Hashie::Mash.new(has_children: true, type: 'numbered_list_item') }
+
+      it { expect(described_class.permitted_children_for?(block: block_notion)).to be(true) }
+    end
+
+    context('when has children and is not permitted') do
+      let(:block_notion) { Hashie::Mash.new(has_children: true, type: 'not_permitted_block') }
+
+      it { expect(described_class.permitted_children_for?(block: block_notion)).to be(false) }
+    end
+
+    context('when has no children and is not permitted') do
+      let(:block_notion) { Hashie::Mash.new(has_children: false, type: 'not_permitted_block') }
+
+      it { expect(described_class.permitted_children_for?(block: block_notion)).to be(false) }
+    end
+
+    context('when has no children and is permitted') do
+      let(:block_notion) { Hashie::Mash.new(has_children: false, type: 'numbered_list_item') }
+
+      it { expect(described_class.permitted_children_for?(block: block_notion)).to be(false) }
+    end
+
+    it 'returns true for permitted block' do
+      %w[bulleted_list_item numbered_list_item paragraph table to_do].each do |type|
+        hashie_block = Hashie::Mash.new(type: type, has_children: true)
+        expect(described_class.permitted_children_for?(block: hashie_block)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/notion_to_md/blocks/normalizer_spec.rb
+++ b/spec/notion_to_md/blocks/normalizer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe(NotionToMd::Blocks::Normalizer) do
+  describe('.normalize') do
+    context('when has bulleted_list_item') do
+      let(:blocks) {
+        [
+          instance_double(NotionToMd::Blocks::Block, type: 'bulleted_list_item'),
+          instance_double(NotionToMd::Blocks::Block, type: 'bulleted_list_item'),
+        ]
+      }
+
+      it 'returns bulleted_list_item' do
+        expect(described_class.normalize(blocks: blocks)).to include(be_a_kind_of(NotionToMd::Blocks::BulletedListBlock))
+      end
+    end
+  end
+end

--- a/spec/notion_to_md/blocks_spec.rb
+++ b/spec/notion_to_md/blocks_spec.rb
@@ -3,39 +3,6 @@
 require 'spec_helper'
 
 describe(NotionToMd::Blocks) do
-  describe('.permitted_children?') do
-    context('when has children and is permitted') do
-      let(:block_notion) { Hashie::Mash.new(has_children: true, type: 'numbered_list_item') }
-
-      it { expect(described_class.permitted_children?(block: block_notion)).to be(true) }
-    end
-
-    context('when has children and is not permitted') do
-      let(:block_notion) { Hashie::Mash.new(has_children: true, type: 'not_permitted_block') }
-
-      it { expect(described_class.permitted_children?(block: block_notion)).to be(false) }
-    end
-
-    context('when has no children and is not permitted') do
-      let(:block_notion) { Hashie::Mash.new(has_children: false, type: 'not_permitted_block') }
-
-      it { expect(described_class.permitted_children?(block: block_notion)).to be(false) }
-    end
-
-    context('when has no children and is permitted') do
-      let(:block_notion) { Hashie::Mash.new(has_children: false, type: 'numbered_list_item') }
-
-      it { expect(described_class.permitted_children?(block: block_notion)).to be(false) }
-    end
-
-    it 'returns true for permitted block' do
-      %w[bulleted_list_item numbered_list_item paragraph table to_do].each do |type|
-        hashie_block = Hashie::Mash.new(type: type, has_children: true)
-        expect(described_class.permitted_children?(block: hashie_block)).to be(true)
-      end
-    end
-  end
-
   describe('.build') do
     let(:page_notion) do
       Hashie::Mash.new(


### PR DESCRIPTION
Normalize block after build. This allows to group blocks like list items in a block so it can be treated so the group of list items can be treated as a list element.