### PR TITLE
fix: unescape encoded links

### DIFF
--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -5,7 +5,7 @@ module NotionToMd
     class Types
       class << self
         def paragraph(block)
-          return blank if block.rich_text.empty?
+          return blank if block[:rich_text].empty?
 
           convert_text(block)
         end
@@ -124,7 +124,7 @@ module NotionToMd
           href = text[:href]
           return content if href.nil?
 
-          "[#{content}](#{href})"
+          "[#{content}](#{CGI.unescape(href)})"
         end
 
         def add_annotations(text, content)

--- a/spec/fixtures/vcr_cassettes/notion_page.yml
+++ b/spec/fixtures/vcr_cassettes/notion_page.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:44 GMT
+      - Sun, 03 Dec 2023 14:28:34 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -31,9 +31,9 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - 6d56a57f-5d02-49f6-bedc-0f7700e355e5
+      - 4ef6c16f-b4e4-40c4-b443-503214657f3e
       etag:
-      - W/"107c-RGAmp+SxZU3vQp32DCXJk+E4ZeM"
+      - W/"107c-WRXwkK+YTVfaw/7aUXCYb/Dfkv4"
       vary:
       - Accept-Encoding
       content-encoding:
@@ -41,16 +41,16 @@ http_interactions:
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=O.NX_VC_eK_hmzUGQRuky0KX_zHu.cgsIRBk9lOji4c-1701557084-0-AY/dR13y+RZjgP6HMA+Q2iiHUnzy17sKJGiBP4oK7kBkVuT0XfPxqJXIDBUJJdY2GDQpbamuwu0WeLYnRdRcNz8=;
-        path=/; expires=Sat, 02-Dec-23 23:14:44 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=xOnAumM8evYaUKcfz1AlJTEhl5jicvbNLq3gaGGICvo-1701613714-0-AShwZQEAKA4Kli3jcg1m7sv6akQyPLLzMz+M6SkL3VrJmpfylvQTzbwhiYLzVPDfqgLPekU2Slunbuad6YMNr2c=;
+        path=/; expires=Sun, 03-Dec-23 14:58:34 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f7189ed82b2a77-CDG
+      - 82fc7f2f88c600a4-CDG
     body:
       encoding: UTF-8
-      string: "{\"object\":\"page\",\"id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\",\"created_time\":\"2022-01-23T12:31:00.000Z\",\"last_edited_time\":\"2023-12-02T22:09:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"cover\":{\"type\":\"external\",\"external\":{\"url\":\"https://www.notion.so/images/page-cover/met_canaletto_1720.jpg\"}},\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A5\"},\"parent\":{\"type\":\"database_id\",\"database_id\":\"1ae33dd5-f331-4402-9480-69517fa40ae2\"},\"archived\":false,\"properties\":{\"empty
+      string: "{\"object\":\"page\",\"id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\",\"created_time\":\"2022-01-23T12:31:00.000Z\",\"last_edited_time\":\"2023-12-03T14:27:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"cover\":{\"type\":\"external\",\"external\":{\"url\":\"https://www.notion.so/images/page-cover/met_canaletto_1720.jpg\"}},\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A5\"},\"parent\":{\"type\":\"database_id\",\"database_id\":\"1ae33dd5-f331-4402-9480-69517fa40ae2\"},\"archived\":false,\"properties\":{\"empty
         date\":{\"id\":\"%3A%7BfH\",\"type\":\"date\",\"date\":null},\"Multi Select\":{\"id\":\"%3C%7Bn%7B\",\"type\":\"multi_select\",\"multi_select\":[{\"id\":\"ddf5e30e-fde6-4023-98a4-864674e8ae87\",\"name\":\"mselect1\",\"color\":\"gray\"},{\"id\":\"1be80fca-a275-4384-8268-6bb2f6a21616\",\"name\":\"mselect2\",\"color\":\"pink\"},{\"id\":\"32e731fc-3fee-41d8-83f5-398b2981f1ac\",\"name\":\"mselect3\",\"color\":\"blue\"}]},\"Select\":{\"id\":\"%3EzjF\",\"type\":\"select\",\"select\":{\"id\":\"fa788fbc-176b-49cb-be2e-552cc985cf7c\",\"name\":\"select1\",\"color\":\"yellow\"}},\"date
         with time\":{\"id\":\"CUEj\",\"type\":\"date\",\"date\":{\"start\":\"2023-12-02T00:00:00.000+01:00\",\"end\":null,\"time_zone\":null}},\"Person\":{\"id\":\"TFSp\",\"type\":\"people\",\"people\":[{\"object\":\"user\",\"id\":\"a4e89628-577b-404f-b62b-36abe7f65fc7\",\"name\":\"John
         Rambo\",\"avatar_url\":\"https://s3-us-west-2.amazonaws.com/public.notion-static.com/3e0bf8de-83a5-4579-8088-5a35021ab9cc/Foto_Perfil_Slack.jpg\",\"type\":\"person\",\"person\":{\"email\":\"gjulia20@gmail.com\"}}]},\"Date\":{\"id\":\"T~YB\",\"type\":\"date\",\"date\":{\"start\":\"2021-12-30\",\"end\":null,\"time_zone\":null}},\"Tags\":{\"id\":\"UT%3Fx\",\"type\":\"multi_select\",\"multi_select\":[{\"id\":\"be6ae2f6-5ae4-496b-b413-f5e7dbeff2a8\",\"name\":\"tag1\",\"color\":\"green\"}]},\"Numbers\":{\"id\":\"a~dg\",\"type\":\"number\",\"number\":12},\"Rich
@@ -58,11 +58,11 @@ http_interactions:
         is a \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"This
         is a \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"rich_text\",\"link\":null},\"annotations\":{\"bold\":true,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"rich_text\",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"
         property. With \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"
-        property. With \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Italics\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Italics\",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\".\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\".\",\"href\":null}]},\"Phone\":{\"id\":\"k%5DEi\",\"type\":\"phone_number\",\"phone_number\":\"983788379\"},\"File\":{\"id\":\"x%60rF\",\"type\":\"files\",\"files\":[{\"name\":\"me.jpeg\",\"type\":\"file\",\"file\":{\"url\":\"https://prod-files-secure.s3.us-west-2.amazonaws.com/4783548e-2442-4bf3-bb3d-ed4ddd2dcdf0/23e8b74e-86d1-4b3a-bd9a-dd0415a954e4/me.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45HZZMZUHI%2F20231202%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20231202T224444Z&X-Amz-Expires=3600&X-Amz-Signature=7ec0b3d66f8db47aab10974b46dbc4a8793bb67dcfeb0abbbf2db57666f76fb2&X-Amz-SignedHeaders=host&x-id=GetObject\",\"expiry_time\":\"2023-12-02T23:44:44.092Z\"}}]},\"empty
+        property. With \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Italics\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Italics\",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\".\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\".\",\"href\":null}]},\"Phone\":{\"id\":\"k%5DEi\",\"type\":\"phone_number\",\"phone_number\":\"983788379\"},\"File\":{\"id\":\"x%60rF\",\"type\":\"files\",\"files\":[{\"name\":\"me.jpeg\",\"type\":\"file\",\"file\":{\"url\":\"https://prod-files-secure.s3.us-west-2.amazonaws.com/4783548e-2442-4bf3-bb3d-ed4ddd2dcdf0/23e8b74e-86d1-4b3a-bd9a-dd0415a954e4/me.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45HZZMZUHI%2F20231203%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20231203T142833Z&X-Amz-Expires=3600&X-Amz-Signature=07bbd011d99cfa5ad388f4dab7e6e873f56b267a45516549b7acb235c593bd22&X-Amz-SignedHeaders=host&x-id=GetObject\",\"expiry_time\":\"2023-12-03T15:28:33.956Z\"}}]},\"empty
         rich text\":{\"id\":\"xtDO\",\"type\":\"rich_text\",\"rich_text\":[]},\"Email\":{\"id\":\"x%7Bcw\",\"type\":\"email\",\"email\":\"hola@test.com\"},\"Checkbox\":{\"id\":\"%7CMPu\",\"type\":\"checkbox\",\"checkbox\":false},\"empty_select\":{\"id\":\"%7DSr%3F\",\"type\":\"select\",\"select\":null},\"Name\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Page
         1\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Page
-        1\",\"href\":null}]}},\"url\":\"https://www.notion.so/Page-1-9dc17c9c9d2e469dbbf0f9648f3288d3\",\"public_url\":null,\"request_id\":\"6d56a57f-5d02-49f6-bedc-0f7700e355e5\"}"
-  recorded_at: Sat, 02 Dec 2023 22:44:44 GMT
+        1\",\"href\":null}]}},\"url\":\"https://www.notion.so/Page-1-9dc17c9c9d2e469dbbf0f9648f3288d3\",\"public_url\":null,\"request_id\":\"4ef6c16f-b4e4-40c4-b443-503214657f3e\"}"
+  recorded_at: Sun, 03 Dec 2023 14:28:34 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/9dc17c9c9d2e469dbbf0f9648f3288d3/children
@@ -84,7 +84,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:44 GMT
+      - Sun, 03 Dec 2023 14:28:34 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -94,9 +94,9 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - bab87ea9-0adf-451c-abf1-149265198421
+      - f91aefcf-cc40-4e41-9deb-7c4914b122b7
       etag:
-      - W/"9639-DnyBFdK5DVyO9mrX4CWULJteu9M"
+      - W/"9bd1-brIHRmCTzeN5CDF7QVsR0Yjg1Vs"
       vary:
       - Accept-Encoding
       content-encoding:
@@ -104,13 +104,13 @@ http_interactions:
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=Mf.ifhvM3da._AXhXCFPePp6wFZ9muYLYh8p7os71k4-1701557084-0-ARy5b7CYhxee/5S8mt5hNetf66ItKUfhbG+IzQM9rruUZnVyjBj9yoXqDOGRzP1ue1IDQPJT8dArHQaK+KoB04g=;
-        path=/; expires=Sat, 02-Dec-23 23:14:44 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=GSEpM1yfBCA70pNI9IEx2xz2SEwgBi2_.wfNyKaLzUU-1701613714-0-AVsE6S3gMl3mme/rr1zHfXQ3K1VBAmDfXXpge2ybPeuiX4WDgrzMGyfyIw1RjsGX5yh94CKYz2fsDuo5LcZ7x/I=;
+        path=/; expires=Sun, 03-Dec-23 14:58:34 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718a0db042a16-CDG
+      - 82fc7f319930702b-CDG
     body:
       encoding: UTF-8
       string: "{\"object\":\"list\",\"results\":[{\"object\":\"block\",\"id\":\"2c3c3f04-448f-4921-aed9-880094afe981\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"image\",\"image\":{\"caption\":[{\"type\":\"text\",\"text\":{\"content\":\"John
@@ -199,19 +199,25 @@ http_interactions:
         dolor sit amet, consectetur adipiscing elit. Quisque ut convallis erat, eget
         egestas magna. Nunc non orci at ante placerat pretium in id justo. Morbi a
         mattis lacus. Nulla tempus, massa a cursus porta, risus leo varius urna, euismod
-        tristique ante metus vitae lacus.\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"gray_background\"}},{\"object\":\"block\",\"id\":\"40db4303-300c-46e2-ab21-e6eb5382d0f6\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Embed\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Embed\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"5c631365-f7cd-4506-8699-8495fe054ba3\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"embed\",\"embed\":{\"caption\":[],\"url\":\"https://www.google.com/maps/place/Guadalajara,+Jal.,+M%C3%A9xico/@20.6737883,-103.3704326,13z/data=!3m1!4b1!4m5!3m4!1s0x8428b18cb52fd39b:0xd63d9302bf865750!8m2!3d20.6596988!4d-103.3496092\"}},{\"object\":\"block\",\"id\":\"c481f321-7cbc-47a0-beba-333021de2fb1\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Bookmark\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Bookmark\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"f84879f3-2670-4a6b-b1fd-e8fc3da09f88\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"bookmark\",\"bookmark\":{\"caption\":[{\"type\":\"text\",\"text\":{\"content\":\"blabla\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"blabla\",\"href\":null}],\"url\":\"https://enriq.me\"}},{\"object\":\"block\",\"id\":\"dca2c1e0-95fa-41a2-8eb3-62d814c7191c\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"divider\",\"divider\":{}},{\"object\":\"block\",\"id\":\"96950caf-66bf-4db7-809a-f0fb0076493c\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"equation\",\"equation\":{\"expression\":\"E=mc^2\"},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"E=mc^2\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"511d0765-ca1f-4b35-aa8c-8d3f6fbd0860\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Links\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Links\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"131bd7c8-418a-45fa-a53a-980c9df402c0\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Lorem
+        tristique ante metus vitae lacus.\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"gray_background\"}},{\"object\":\"block\",\"id\":\"40db4303-300c-46e2-ab21-e6eb5382d0f6\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Embed\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Embed\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"5c631365-f7cd-4506-8699-8495fe054ba3\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"embed\",\"embed\":{\"caption\":[],\"url\":\"https://www.google.com/maps/place/Guadalajara,+Jal.,+M%C3%A9xico/@20.6737883,-103.3704326,13z/data=!3m1!4b1!4m5!3m4!1s0x8428b18cb52fd39b:0xd63d9302bf865750!8m2!3d20.6596988!4d-103.3496092\"}},{\"object\":\"block\",\"id\":\"c481f321-7cbc-47a0-beba-333021de2fb1\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Bookmark\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Bookmark\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"f84879f3-2670-4a6b-b1fd-e8fc3da09f88\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"bookmark\",\"bookmark\":{\"caption\":[{\"type\":\"text\",\"text\":{\"content\":\"blabla\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"blabla\",\"href\":null}],\"url\":\"https://enriq.me\"}},{\"object\":\"block\",\"id\":\"dca2c1e0-95fa-41a2-8eb3-62d814c7191c\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"divider\",\"divider\":{}},{\"object\":\"block\",\"id\":\"96950caf-66bf-4db7-809a-f0fb0076493c\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"equation\",\"equation\":{\"expression\":\"E=mc^2\"},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"E=mc^2\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"511d0765-ca1f-4b35-aa8c-8d3f6fbd0860\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2022-02-13T14:12:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Links\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Links\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"131bd7c8-418a-45fa-a53a-980c9df402c0\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-02-13T14:12:00.000Z\",\"last_edited_time\":\"2023-12-03T14:27:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Lorem
         ipsum dolor sit amet\",\"link\":{\"url\":\"https://google.fr/\"}},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Lorem
         ipsum dolor sit amet\",\"href\":\"https://google.fr/\"},{\"type\":\"text\",\"text\":{\"content\":\",
-        consectetur adipiscing elit. Nulla quis neque vel odio lobortis posuere nec
-        sit amet erat. Morbi congue velit quis ante accumsan volutpat. Nam ornare
-        enim eu metus consectetur facilisis. Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Quisque ut convallis erat, eget egestas magna. Nunc non orci
-        at ante placerat pretium in id justo. Morbi a mattis lacus. \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\",
-        consectetur adipiscing elit. Nulla quis neque vel odio lobortis posuere nec
-        sit amet erat. Morbi congue velit quis ante accumsan volutpat. Nam ornare
-        enim eu metus consectetur facilisis. Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Quisque ut convallis erat, eget egestas magna. Nunc non orci
-        at ante placerat pretium in id justo. Morbi a mattis lacus. \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Nulla
+        consectetur adipiscing elit. \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\",
+        consectetur adipiscing elit. \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Nulla
+        quis neque vel odio\",\"link\":{\"url\":\"https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193\"}},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Nulla
+        quis neque vel odio\",\"href\":\"https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193\"},{\"type\":\"text\",\"text\":{\"content\":\"
+        lobortis posuere nec sit amet erat. \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"
+        lobortis posuere nec sit amet erat. \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Morbi
+        congue velit quis\",\"link\":{\"url\":\"https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193\"}},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Morbi
+        congue velit quis\",\"href\":\"https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193\"},{\"type\":\"text\",\"text\":{\"content\":\"
+        ante accumsan volutpat. Nam ornare enim eu metus consectetur facilisis. Lorem
+        ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut convallis erat,
+        eget egestas magna. Nunc non orci at ante placerat pretium in id justo. Morbi
+        a mattis lacus. \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"
+        ante accumsan volutpat. Nam ornare enim eu metus consectetur facilisis. Lorem
+        ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut convallis erat,
+        eget egestas magna. Nunc non orci at ante placerat pretium in id justo. Morbi
+        a mattis lacus. \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"Nulla
         tempus, massa a cursus porta, risus leo varius urna, euismod tristique ante
         metus vitae lacus\",\"link\":{\"url\":\"https://swile.co/\"}},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Nulla
         tempus, massa a cursus porta, risus leo varius urna, euismod tristique ante
@@ -232,8 +238,8 @@ http_interactions:
         \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"bold \",\"link\":null},\"annotations\":{\"bold\":true,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"bold
         \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"strike \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":true,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"strike
         \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"inline-code \",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":true,\"color\":\"default\"},\"plain_text\":\"inline-code
-        \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"underline\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":true,\"code\":false,\"color\":\"default\"},\"plain_text\":\"underline\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"fe993569-504e-49b6-8252-00120b69253b\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"6c48a070-7a58-4a73-a971-6cc72bed0860\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"italic\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"italic\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"173c6135-47dc-4341-933e-4ee39aa020d8\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"bold\",\"link\":null},\"annotations\":{\"bold\":true,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"bold\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"120525d0-794f-413c-9c6e-78a57ed50a5d\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"strike-trough\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":true,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"strike-trough\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"524e6f1f-6461-4858-a6e0-be80d1c55847\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"underline\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":true,\"code\":false,\"color\":\"default\"},\"plain_text\":\"underline\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"6f903eac-0704-4f2f-958d-402d4612c369\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-10-04T20:23:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"inline-code\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":true,\"color\":\"default\"},\"plain_text\":\"inline-code\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"bc6fa4ec-7edf-468b-b436-59d9379f0b41\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-09-16T03:45:00.000Z\",\"last_edited_time\":\"2022-09-16T16:14:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Tables\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Tables\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"fffe8b14-de13-420e-af3b-c000cc73fb89\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-09-16T03:46:00.000Z\",\"last_edited_time\":\"2022-10-04T20:23:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":true,\"archived\":false,\"type\":\"table\",\"table\":{\"table_width\":3,\"has_column_header\":true,\"has_row_header\":false}}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"bab87ea9-0adf-451c-abf1-149265198421\"}"
-  recorded_at: Sat, 02 Dec 2023 22:44:44 GMT
+        \",\"href\":null},{\"type\":\"text\",\"text\":{\"content\":\"underline\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":true,\"code\":false,\"color\":\"default\"},\"plain_text\":\"underline\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"fe993569-504e-49b6-8252-00120b69253b\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"6c48a070-7a58-4a73-a971-6cc72bed0860\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"italic\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":true,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"italic\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"173c6135-47dc-4341-933e-4ee39aa020d8\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"bold\",\"link\":null},\"annotations\":{\"bold\":true,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"bold\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"120525d0-794f-413c-9c6e-78a57ed50a5d\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"strike-trough\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":true,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"strike-trough\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"524e6f1f-6461-4858-a6e0-be80d1c55847\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-03-18T10:13:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"underline\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":true,\"code\":false,\"color\":\"default\"},\"plain_text\":\"underline\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"6f903eac-0704-4f2f-958d-402d4612c369\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-03-18T10:13:00.000Z\",\"last_edited_time\":\"2022-10-04T20:23:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"paragraph\",\"paragraph\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"inline-code\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":true,\"color\":\"default\"},\"plain_text\":\"inline-code\",\"href\":null}],\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"bc6fa4ec-7edf-468b-b436-59d9379f0b41\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-09-16T03:45:00.000Z\",\"last_edited_time\":\"2022-09-16T16:14:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":false,\"archived\":false,\"type\":\"heading_3\",\"heading_3\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"Tables\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Tables\",\"href\":null}],\"is_toggleable\":false,\"color\":\"default\"}},{\"object\":\"block\",\"id\":\"fffe8b14-de13-420e-af3b-c000cc73fb89\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"9dc17c9c-9d2e-469d-bbf0-f9648f3288d3\"},\"created_time\":\"2022-09-16T03:46:00.000Z\",\"last_edited_time\":\"2022-10-04T20:23:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"db313571-0280-411f-a6de-70e826421d12\"},\"has_children\":true,\"archived\":false,\"type\":\"table\",\"table\":{\"table_width\":3,\"has_column_header\":true,\"has_row_header\":false}}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"f91aefcf-cc40-4e41-9deb-7c4914b122b7\"}"
+  recorded_at: Sun, 03 Dec 2023 14:28:34 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/5db39f27-3de4-4469-94b8-3cf512f812e8/children
@@ -255,7 +261,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:45 GMT
+      - Sun, 03 Dec 2023 14:28:34 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -265,9 +271,9 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - 72276fcd-94b5-45e1-bfce-d958dd959c10
+      - daf19f7f-a4ea-44d2-8228-fa27a93e3106
       etag:
-      - W/"61a-AVqhHZrjNFfzaVvfxxkrrQuOtnU"
+      - W/"61a-VjL2yBz36+iC+YmiORiSRhZUbgA"
       vary:
       - Accept-Encoding
       content-encoding:
@@ -275,21 +281,21 @@ http_interactions:
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=qjRXtxQjDPrT4gRHPvfLJj7Un1z08H11EQfmbLZ36AQ-1701557085-0-AbFZfp+PWLDUi0+VXNtWqHESR7B7pbsLHMDDVyT/WMm4tSAbQuXkXn6cFMaDByYIDnDlViohu0nKLaWHs7wAMJQ=;
-        path=/; expires=Sat, 02-Dec-23 23:14:45 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=VaQTCZHVTE6d8qdzfTDYYSaogOqGPGsBKkNGvHIgkSc-1701613714-0-AT/AKTJtc2YLxRgXMaRkEjBTXdqAqw+ifGGnSClSO+EE7S/hnfR2fDQLlrYd3TA1r5zEHWWR3pXTwplkJ64QYUw=;
+        path=/; expires=Sun, 03-Dec-23 14:58:34 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718a3593e02bd-CDG
+      - 82fc7f343dfe701b-CDG
     body:
       encoding: UTF-8
       string: '{"object":"list","results":[{"object":"block","id":"a7084141-6cc5-42a4-add6-f29f8b74d8e8","parent":{"type":"block_id","block_id":"5db39f27-3de4-4469-94b8-3cf512f812e8"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2022-09-03T12:45:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":true,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         2","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
         2","href":null}],"color":"default"}},{"object":"block","id":"b9f715d0-9b99-4519-8e55-72d099e3f455","parent":{"type":"block_id","block_id":"5db39f27-3de4-4469-94b8-3cf512f812e8"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2023-11-22T06:30:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         4","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
-        4","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"72276fcd-94b5-45e1-bfce-d958dd959c10"}'
-  recorded_at: Sat, 02 Dec 2023 22:44:45 GMT
+        4","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"daf19f7f-a4ea-44d2-8228-fa27a93e3106"}'
+  recorded_at: Sun, 03 Dec 2023 14:28:34 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/a7084141-6cc5-42a4-add6-f29f8b74d8e8/children
@@ -311,7 +317,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:45 GMT
+      - Sun, 03 Dec 2023 14:28:38 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -321,29 +327,29 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - 9e224e25-0d7b-462c-8b8f-9fb299ee7444
+      - f09b585e-9571-4e97-b94b-2480f550cb75
       etag:
-      - W/"355-q/pI+lLXPHfKVSkbhEOgvw+GOIg"
+      - W/"355-XcA6JLXRWBdWYNQoiJQMrLUuhjI"
       vary:
       - Accept-Encoding
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=z1Y5lr4Xrfwev24Z8Z1oxy_758yBYt3SrB6PFE6GUE8-1701557085-0-AdS4y6DsO1+Ax6DE2BeKTfyVzfUhVmvaORlTKBl2h42fJCdcy4CBDJQq0cdcwgRSl8F+/M21HgHrFOMR6QXfIvw=;
-        path=/; expires=Sat, 02-Dec-23 23:14:45 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=ziXVgsjpNoyqy9apxmIftVOqQkzNVnNN1SNTtknoYMk-1701613718-0-ATbhW5xZeoqH5zfTG5SVsii7BNTR5//Y+9T7I5i25z+OSOSKpbSakCkbQJbnfuyu8azRM7HYQiVXtVdvLS+wlgE=;
+        path=/; expires=Sun, 03-Dec-23 14:58:38 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718a77e0bf135-CDG
+      - 82fc7f35da21016d-CDG
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
       string: '{"object":"list","results":[{"object":"block","id":"540bd8c0-200e-4630-b87a-7827bcd311b0","parent":{"type":"block_id","block_id":"a7084141-6cc5-42a4-add6-f29f8b74d8e8"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2022-09-03T12:45:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         3","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
-        3","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"9e224e25-0d7b-462c-8b8f-9fb299ee7444"}'
-  recorded_at: Sat, 02 Dec 2023 22:44:45 GMT
+        3","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"f09b585e-9571-4e97-b94b-2480f550cb75"}'
+  recorded_at: Sun, 03 Dec 2023 14:28:38 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/49fcc456-2bec-43af-81ba-962dc4cf9465/children
@@ -365,7 +371,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:45 GMT
+      - Sun, 03 Dec 2023 14:28:38 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -375,9 +381,9 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - d7cb72a7-4693-474c-9bab-82d7c69c3184
+      - e34c7507-a850-41f0-9252-678367aec00e
       etag:
-      - W/"61a-MZhh4SVn9Qagtdgy1tPNTl4D8xo"
+      - W/"61a-uKEenj8iqO+UBgVv5vgSpppH8SU"
       vary:
       - Accept-Encoding
       content-encoding:
@@ -385,21 +391,21 @@ http_interactions:
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=26jz3XsrIUj2HJHDkJ3hLfOjq66uRDD4QP29K8_XNbE-1701557085-0-Aa8HWOBEK2jnsYjZ5iGDg6Tur/uZ6wbexA8DAy/dYBMj1qZXmflCKnH0UDGt7ZJeXtemBv8FOiEqY3wiZyNX5ug=;
-        path=/; expires=Sat, 02-Dec-23 23:14:45 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=0p6Xyg3hu.ICKZNhxyrgoZ72CLyGV5WvO6OSfT1jDVM-1701613718-0-AQDWLpuWPGZ9/FcYYHJzRPUDollvaMy6z2YCWKNnx1c7xdaRvtHHSU3PpHZjRJROku4LkfjylMyPv+BxlDcJvrE=;
+        path=/; expires=Sun, 03-Dec-23 14:58:38 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718a92a0f2a3f-CDG
+      - 82fc7f4dfef30246-CDG
     body:
       encoding: UTF-8
       string: '{"object":"list","results":[{"object":"block","id":"9134a99f-b20a-4ba0-adfb-253a4da8ae10","parent":{"type":"block_id","block_id":"49fcc456-2bec-43af-81ba-962dc4cf9465"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2022-09-03T12:45:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":true,"archived":false,"type":"numbered_list_item","numbered_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         2","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
         2","href":null}],"color":"default"}},{"object":"block","id":"a2e61f44-22d9-4454-aba9-0b34dc5d8b73","parent":{"type":"block_id","block_id":"49fcc456-2bec-43af-81ba-962dc4cf9465"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2023-11-22T06:30:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"numbered_list_item","numbered_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         4","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
-        4","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"d7cb72a7-4693-474c-9bab-82d7c69c3184"}'
-  recorded_at: Sat, 02 Dec 2023 22:44:45 GMT
+        4","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"e34c7507-a850-41f0-9252-678367aec00e"}'
+  recorded_at: Sun, 03 Dec 2023 14:28:38 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/9134a99f-b20a-4ba0-adfb-253a4da8ae10/children
@@ -421,7 +427,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:46 GMT
+      - Sun, 03 Dec 2023 14:28:39 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -431,29 +437,29 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - fc70f3ff-ee44-4de2-a4e6-26b9ba79e49f
+      - eac96430-031a-46e9-b339-dabecc251bcb
       etag:
-      - W/"355-mkEe4nSNUzBOkyNn0wDxLq8YPrk"
+      - W/"355-zEoxeL8BAq8VyTbOIrVR7zjxdBk"
       vary:
       - Accept-Encoding
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=7oBoDdlFbhisfAVGMdWXi6EwSMN1CF916p2dS_iO1xo-1701557086-0-AeZnIS6W16d2T34V1dxsLoGnUQVIbUquKu4K7xL8OG9ohvP26TiJzInlD/ngBZO1YwCXaXHcjGAgHan1GjN9hYE=;
-        path=/; expires=Sat, 02-Dec-23 23:14:46 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=bgiMM38Yx6kU9n1Oap1Z8X7NgIQ5uBWq6LhGFI1qspg-1701613719-0-ASrAnmAHpbKl5hrwOGlD+psxWXTASo1MYllZZEBY1jlPqQR6/dfMlGMIdqWbDm2krq7hI1IwPUNcZZpxa1sdAaI=;
+        path=/; expires=Sun, 03-Dec-23 14:58:39 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718aae9326eb5-CDG
+      - 82fc7f4faf7f2a28-CDG
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
       string: '{"object":"list","results":[{"object":"block","id":"32a9f186-d1ae-496c-98f6-f56df912ec18","parent":{"type":"block_id","block_id":"9134a99f-b20a-4ba0-adfb-253a4da8ae10"},"created_time":"2022-09-03T12:45:00.000Z","last_edited_time":"2023-11-22T06:30:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"numbered_list_item","numbered_list_item":{"rich_text":[{"type":"text","text":{"content":"item
         3","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"item
-        3","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"fc70f3ff-ee44-4de2-a4e6-26b9ba79e49f"}'
-  recorded_at: Sat, 02 Dec 2023 22:44:46 GMT
+        3","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"eac96430-031a-46e9-b339-dabecc251bcb"}'
+  recorded_at: Sun, 03 Dec 2023 14:28:39 GMT
 - request:
     method: get
     uri: https://api.notion.com/v1/blocks/fffe8b14-de13-420e-af3b-c000cc73fb89/children
@@ -475,7 +481,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Sat, 02 Dec 2023 22:44:47 GMT
+      - Sun, 03 Dec 2023 14:28:39 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -485,9 +491,9 @@ http_interactions:
       x-powered-by:
       - Express
       x-notion-request-id:
-      - 30fc5d9e-d51f-4f8c-893c-16886de3b61c
+      - f87820ea-300e-4646-903f-cde33331a73d
       etag:
-      - W/"c85-fncjzXdNNd4lt4Uns7CF3kiPY6M"
+      - W/"c85-c3l5PLkoH9blECyKgWYP+Ycjxhw"
       vary:
       - Accept-Encoding
       content-encoding:
@@ -495,13 +501,13 @@ http_interactions:
       cf-cache-status:
       - DYNAMIC
       set-cookie:
-      - __cf_bm=wN_nmXfFIomI0fFLh7uBK4anLGSZr93n5Xup48UMz14-1701557087-0-AT9YUJ3WZFEbdRZzDgghbzZbBV71aLyvIr1Q9OfKRm1jhfG//xB8A+YIenY5IvEept/PaJsX4Vd0I0MzBJ4xVxY=;
-        path=/; expires=Sat, 02-Dec-23 23:14:47 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=rTAC87YF4JgFiEz_FXvl1B7eb.9DRwXWaoAEGmYUVj4-1701613719-0-ARwsdIiBgBMi+K4+Az+69m6NoVqYrkmc5OYkvsV13RRqQvs8Azf1XrGtKOg8oIgi1A5daFEz2HdZLRa2OIl2jl8=;
+        path=/; expires=Sun, 03-Dec-23 14:58:39 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
       server:
       - cloudflare
       cf-ray:
-      - 82f718ad6a1e99b4-CDG
+      - 82fc7f513d066ff6-CDG
     body:
       encoding: UTF-8
       string: '{"object":"list","results":[{"object":"block","id":"9446a67d-ec5e-4738-85e7-7f3f028c5f4e","parent":{"type":"block_id","block_id":"fffe8b14-de13-420e-af3b-c000cc73fb89"},"created_time":"2022-09-16T03:46:00.000Z","last_edited_time":"2022-09-16T03:47:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"table_row","table_row":{"cells":[[],[{"type":"text","text":{"content":"Column
@@ -511,6 +517,6 @@ http_interactions:
         1","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Row
         1","href":null}],[{"type":"text","text":{"content":"ñaña","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"ñaña","href":null}],[{"type":"text","text":{"content":"blabla","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"blabla","href":null}]]}},{"object":"block","id":"5f0644ce-d674-476d-8182-b2985abc8a87","parent":{"type":"block_id","block_id":"fffe8b14-de13-420e-af3b-c000cc73fb89"},"created_time":"2022-09-16T03:46:00.000Z","last_edited_time":"2022-09-16T03:47:00.000Z","created_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"last_edited_by":{"object":"user","id":"db313571-0280-411f-a6de-70e826421d12"},"has_children":false,"archived":false,"type":"table_row","table_row":{"cells":[[{"type":"text","text":{"content":"Row
         2","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Row
-        2","href":null}],[{"type":"text","text":{"content":"prupru","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"prupru","href":null}],[{"type":"text","text":{"content":"tinonino","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"tinonino","href":null}]]}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"30fc5d9e-d51f-4f8c-893c-16886de3b61c"}'
-  recorded_at: Sat, 02 Dec 2023 22:44:47 GMT
+        2","href":null}],[{"type":"text","text":{"content":"prupru","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"prupru","href":null}],[{"type":"text","text":{"content":"tinonino","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"tinonino","href":null}]]}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"f87820ea-300e-4646-903f-cde33331a73d"}'
+  recorded_at: Sun, 03 Dec 2023 14:28:39 GMT
 recorded_with: VCR 6.2.0

--- a/spec/notion_to_md/blocks/types_spec.rb
+++ b/spec/notion_to_md/blocks/types_spec.rb
@@ -80,4 +80,98 @@ describe(NotionToMd::Blocks::Types) do
       it { expect(described_class.code(block_code)).to end_with('```') }
     end
   end
+
+  describe('.paragraph') do
+    context('when rich_text is empty') do
+      let(:block_paragraph) do
+        {
+          rich_text: []
+        }
+      end
+
+      it { expect(described_class.paragraph(block_paragraph)).to eq('<br />') }
+    end
+
+    context('when rich_text is not empty') do
+      let(:block_paragraph) do
+        {
+          rich_text: [{
+            type: 'text',
+            plain_text: 'This is a paragraph',
+            href: nil,
+            text: {
+              content: 'This is a paragraph',
+              link: nil
+            },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default'
+            }
+          }]
+        }
+      end
+
+      it { expect(described_class.paragraph(block_paragraph)).to eq("#{block_paragraph[:rich_text][0][:plain_text]}") }
+    end
+
+    context('when rich_text is not empty and has a link') do
+      let(:block_paragraph) do
+        {
+          rich_text: [{
+            type: 'text',
+            plain_text: 'This is a paragraph',
+            href: 'https://www.google.com',
+            text: {
+              content: 'This is a paragraph',
+              link: {
+                url: 'https://www.google.com'
+              }
+            },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default'
+            }
+          }]
+        }
+      end
+
+      it { expect(described_class.paragraph(block_paragraph)).to eq("[#{block_paragraph[:rich_text][0][:plain_text]}](#{block_paragraph[:rich_text][0][:href]})") }
+    end
+
+    context('when rich_text is not empty and has a encoded link') do
+      let(:block_paragraph) do
+        {
+          rich_text: [{
+            type: 'text',
+            plain_text: 'This is a paragraph',
+            href: 'https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193',
+            text: {
+              content: 'This is a paragraph',
+              link: {
+                url: 'https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193'
+              }
+            },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default'
+            }
+          }]
+        }
+      end
+
+      it { expect(described_class.paragraph(block_paragraph)).to eq("[#{block_paragraph[:rich_text][0][:plain_text]}](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/bin/initdb/initdb.c;h=c854221a30602c5a1e5abf73b0942b263859d715;hb=HEAD#l3193)") }
+    end
+  end
 end

--- a/spec/notion_to_md_spec.rb
+++ b/spec/notion_to_md_spec.rb
@@ -98,6 +98,12 @@ describe(NotionToMd) do
       expect(md).to matching(/^`inline-code`$/)
     end
 
+    it 'sets links in markdown' do
+      expect(md).to matching(%r{\[Lorem ipsum dolor sit amet\]\(https://google.fr/\)})
+      expect(md).to matching(%r{\[Nulla quis neque vel odio\]\(https://git.postgresql.org/gitweb/\?p=postgresql.git;a=blob;f=src/bin/initdb/initdb.c;h=c854221a30602c5a1e5abf73b0942b263859d715;hb=HEAD#l3193\)})
+      expect(md).to matching(%r{\[Nulla tempus, massa a cursus porta, risus leo varius urna, euismod tristique ante metus vitae lacus\]\(https://swile.co/\)})
+    end
+
     context('with frontmatter') do
       subject(:md) do
         VCR.use_cassette("notion_page") do
@@ -120,7 +126,7 @@ describe(NotionToMd) do
       end
 
       it 'sets last_edited_time in frontmatter' do
-        expect(md).to matching(/^last_edited_time: 2023-12-02T22:09:00.000Z$/)
+        expect(md).to matching(/^last_edited_time: 2023-12-03T14:27:00.000Z$/)
       end
 
       it 'sets icon in frontmatter' do


### PR DESCRIPTION
Unescape encoded URL like this one `https://git.postgresql.org/gitweb/?p=postgresql.git%3Ba%3Dblob%3Bf%3Dsrc%2Fbin%2Finitdb%2Finitdb.c%3Bh%3Dc854221a30602c5a1e5abf73b0942b263859d715%3Bhb%3DHEAD#l3193` to this `https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/bin/initdb/initdb.c;h=c854221a30602c5a1e5abf73b0942b263859d715;hb=HEAD#l3193`